### PR TITLE
Add zip download feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/js/app.js
+++ b/js/app.js
@@ -1,2 +1,16 @@
 // Main application entry point
-console.log("App loaded");
+import { downloadBlobsAsZip } from './downloadZip.js';
+
+// Array holding blobs to be exported. Other modules can push to this array.
+export const storedBlobs = [];
+
+const rightPanel = document.getElementById('rightPanel');
+if (rightPanel) {
+  const button = document.createElement('button');
+  button.id = 'downloadZipButton';
+  button.textContent = 'Download ZIP';
+  button.addEventListener('click', () => downloadBlobsAsZip(storedBlobs));
+  rightPanel.appendChild(button);
+}
+
+console.log('App loaded');

--- a/js/downloadZip.js
+++ b/js/downloadZip.js
@@ -1,0 +1,25 @@
+import JSZip from 'jszip';
+
+/**
+ * Generate a ZIP from the provided blobs and trigger a client-side download.
+ * @param {Blob[]} blobs array of Blob objects to include in the zip
+ */
+export async function downloadBlobsAsZip(blobs) {
+  if (!blobs || blobs.length === 0) {
+    return;
+  }
+  const zip = new JSZip();
+  blobs.forEach((blob, i) => {
+    const name = `FakeID_${i}.png`;
+    zip.file(name, blob);
+  });
+  const content = await zip.generateAsync({ type: 'blob' });
+  const url = URL.createObjectURL(content);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'FakeIDs.zip';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "license": "ISC",
   "devDependencies": {
     "http-server": "^14.1.1"
+  },
+  "dependencies": {
+    "jszip": "^3.10.1"
   }
 }


### PR DESCRIPTION
## Summary
- install jszip in `package.json`
- ignore `node_modules` and `package-lock.json`
- add module for downloading blobs as a ZIP archive
- wire the new download button in the app

## Testing
- `node --version`
- `npm --version`
