### PR TITLE
Add live style controls for fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
     <div id="leftPanel"></div>
-    <div id="canvasWrapper"></div>
+    <div id="canvasWrapper">
+        <div class="field" data-id="name" style="position:absolute; top:50px; left:50px;">Name</div>
+        <div class="field" data-id="title" style="position:absolute; top:100px; left:50px;">Title</div>
+    </div>
     <div id="rightPanel"></div>
 
     <script type="module" src="js/app.js"></script>

--- a/js/FieldManager.js
+++ b/js/FieldManager.js
@@ -1,0 +1,59 @@
+class FieldManager extends EventTarget {
+    constructor(persistence) {
+        super();
+        this.persistence = persistence;
+        this.fields = new Map(); // id -> {element, styles}
+        this.selectedFieldId = null;
+    }
+
+    init() {
+        const persisted = this.persistence.load();
+        document.querySelectorAll('.field').forEach((el, index) => {
+            const id = el.dataset.id || `field-${index}`;
+            el.dataset.id = id;
+            const styles = persisted[id]?.styles || {};
+            if (styles.fontFamily) el.style.fontFamily = styles.fontFamily;
+            if (styles.fontSize) el.style.fontSize = styles.fontSize;
+            this.fields.set(id, { element: el, styles });
+            el.addEventListener('click', () => this.selectField(id));
+        });
+    }
+
+    selectField(id) {
+        if (this.selectedFieldId) {
+            const prev = this.fields.get(this.selectedFieldId)?.element;
+            if (prev) prev.classList.remove('selected');
+        }
+        this.selectedFieldId = id;
+        const el = this.fields.get(id)?.element;
+        if (el) el.classList.add('selected');
+        this.dispatchEvent(new CustomEvent('fieldSelected', { detail: this.getSelectedField() }));
+    }
+
+    getSelectedField() {
+        if (!this.selectedFieldId) return null;
+        const data = this.fields.get(this.selectedFieldId);
+        return { id: this.selectedFieldId, element: data.element, styles: data.styles };
+    }
+
+    updateStyle(styleUpdates) {
+        const selected = this.getSelectedField();
+        if (!selected) return;
+        const { id, element, styles } = selected;
+        Object.assign(styles, styleUpdates);
+        if (styleUpdates.fontFamily) element.style.fontFamily = styleUpdates.fontFamily;
+        if (styleUpdates.fontSize) element.style.fontSize = styleUpdates.fontSize;
+        this.persistence.save(this.exportData());
+        this.dispatchEvent(new CustomEvent('styleChanged', { detail: this.getSelectedField() }));
+    }
+
+    exportData() {
+        const data = {};
+        this.fields.forEach((value, id) => {
+            data[id] = { styles: value.styles };
+        });
+        return data;
+    }
+}
+
+export default FieldManager;

--- a/js/PositionPersistence.js
+++ b/js/PositionPersistence.js
@@ -1,0 +1,25 @@
+class PositionPersistence {
+    constructor(key = 'fieldData') {
+        this.key = key;
+    }
+
+    load() {
+        const raw = localStorage.getItem(this.key);
+        if (!raw) return {};
+        try {
+            return JSON.parse(raw);
+        } catch {
+            return {};
+        }
+    }
+
+    save(data) {
+        try {
+            localStorage.setItem(this.key, JSON.stringify(data));
+        } catch {
+            // ignore storage errors
+        }
+    }
+}
+
+export default PositionPersistence;

--- a/js/app.js
+++ b/js/app.js
@@ -1,2 +1,12 @@
-// Main application entry point
-console.log("App loaded");
+import PositionPersistence from './PositionPersistence.js';
+import FieldManager from './FieldManager.js';
+import initStyleControls from './styleControls.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const persistence = new PositionPersistence();
+    const fieldManager = new FieldManager(persistence);
+    fieldManager.init();
+    initStyleControls(fieldManager);
+
+    console.log('App loaded');
+});

--- a/js/styleControls.js
+++ b/js/styleControls.js
@@ -1,0 +1,58 @@
+export default function initStyleControls(fieldManager) {
+    const panel = document.getElementById('leftPanel');
+    if (!panel) return;
+
+    const container = document.createElement('div');
+    container.id = 'styleControls';
+    container.style.display = 'none';
+
+    // Font family dropdown
+    const familyLabel = document.createElement('label');
+    familyLabel.textContent = 'Font Family:';
+    const familySelect = document.createElement('select');
+    ['Arial', 'Courier New', 'Times New Roman', 'Sans-serif'].forEach(f => {
+        const opt = document.createElement('option');
+        opt.value = f;
+        opt.textContent = f;
+        familySelect.appendChild(opt);
+    });
+
+    // Font size slider
+    const sizeLabel = document.createElement('label');
+    sizeLabel.textContent = 'Font Size:';
+    const sizeSlider = document.createElement('input');
+    sizeSlider.type = 'range';
+    sizeSlider.min = '8';
+    sizeSlider.max = '72';
+
+    container.appendChild(familyLabel);
+    container.appendChild(familySelect);
+    container.appendChild(sizeLabel);
+    container.appendChild(sizeSlider);
+
+    panel.appendChild(container);
+
+    const showControls = fieldData => {
+        if (!fieldData) {
+            container.style.display = 'none';
+            return;
+        }
+        container.style.display = 'block';
+        familySelect.value = fieldData.styles.fontFamily || 'Arial';
+        const size = parseInt(fieldData.styles.fontSize, 10);
+        sizeSlider.value = size || 16;
+    };
+
+    fieldManager.addEventListener('fieldSelected', e => showControls(e.detail));
+
+    familySelect.addEventListener('change', () => {
+        fieldManager.updateStyle({ fontFamily: familySelect.value });
+    });
+
+    sizeSlider.addEventListener('input', () => {
+        fieldManager.updateStyle({ fontSize: `${sizeSlider.value}px` });
+    });
+
+    // Show current selected field if any at init
+    showControls(fieldManager.getSelectedField());
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -10,10 +10,24 @@ body {
 #leftPanel {
     flex: 1;
     border-right: 1px solid #ddd;
+    padding: 10px;
 }
 
 #canvasWrapper {
     flex: 3;
+    position: relative;
+    border: 1px solid #ddd;
+}
+
+.field {
+    cursor: pointer;
+    padding: 4px 8px;
+    border: 1px dashed transparent;
+    user-select: none;
+}
+
+.field.selected {
+    border-color: #00f;
 }
 
 #rightPanel {


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore `node_modules` and lockfile
- create basic FieldManager and PositionPersistence modules
- add styleControls for selecting fonts and size
- update `app.js` to initialize new modules
- add sample field elements and styling

## Testing
- `npm test` *(fails: Missing script)*