### PR TITLE
Add window resize handling to field manager

### DIFF
--- a/js/fieldManager.js
+++ b/js/fieldManager.js
@@ -14,6 +14,7 @@ export function initializeFieldManager(canvasElement) {
   if (canvasWrapper) {
     canvasWrapper.appendChild(fieldLayer);
     updateFieldLayerPosition();
+    window.addEventListener('resize', updateFieldLayerPosition);
     document.addEventListener('click', handleDocumentClick, true); // Use capture to ensure it runs
   } else {
     console.error('Canvas wrapper not found for field layer.');
@@ -243,6 +244,11 @@ export function clearFields() {
     }
     fieldCounter = 0;
     setFocusedField(null);
+}
+
+export function cleanupFieldManager() {
+    window.removeEventListener('resize', updateFieldLayerPosition);
+    document.removeEventListener('click', handleDocumentClick, true);
 }
 
 // Expose fieldLayer for app.js to potentially listen to events on it


### PR DESCRIPTION
## Summary
- ensure draggable fields stay aligned with canvas on window resize
- provide a cleanup function for removing event listeners

## Testing
- `npm test` *(fails: Missing script)*