### PR TITLE
Serve index.html for /index.html requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const server = Bun.serve({
     const pathname = url.pathname;
 
     // Serve index.html for the root path
-    if (pathname === "/") {
+    if (pathname === "/" || pathname === "/index.html") {
       const filePath = path.join(import.meta.dir, "index.html");
       if (existsSync(filePath)) {
         const file = Bun.file(filePath);


### PR DESCRIPTION
## Summary
- adjust root handler to also match `/index.html`

## Testing
- `bun server.js` (in background)
- `curl -I http://localhost:3000/index.html`
- `curl -I http://localhost:3000/`
