### PR TITLE
Add font customization for text fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,21 @@
         <div class="form-group"><button id="addExpiryDateField">Add Expiry Date</button></div>
         <div class="form-group"><button id="addCivilNoField">Add Civil Number</button></div>
         <div class="form-group"><button id="addPhotoField">Add Photo Area</button></div>
+        <hr>
+        <h4>Field Font</h4>
+        <div class="form-group">
+            <label for="fontFamilySelect">Font Family:</label>
+            <select id="fontFamilySelect">
+                <option value="Arial">Arial</option>
+                <option value="Courier New">Courier New</option>
+                <option value="Times New Roman">Times New Roman</option>
+                <option value="Verdana">Verdana</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="fontSizeInput">Font Size (px):</label>
+            <input type="number" id="fontSizeInput" value="16" min="6">
+        </div>
     </div>
 
     <div id="canvasWrapper">

--- a/js/app.js
+++ b/js/app.js
@@ -17,11 +17,14 @@ const numIDsToGenerateInput = document.getElementById('numIDsToGenerate');
 const generateButton = document.getElementById('generateButton');
 const downloadPreviewButton = document.getElementById('downloadPreviewButton');
 const downloadAllButton = document.getElementById('downloadAllButton');
+const fontFamilySelect = document.getElementById('fontFamilySelect');
+const fontSizeInput = document.getElementById('fontSizeInput');
 
 // App State
 let templateImage = null;
-let fields = {}; // Stores configuration of added fields: { id: {type, x, y, width, height, text} }
+let fields = {}; // Stores configuration of added fields: { id: {type, x, y, width, height, text, fontFamily, fontSize} }
 let generatedIdObjects = []; // Stores { name: string, dataUrl: string } for generated IDs
+let selectedFieldId = null;
 
 // Initialize field manager with the canvas
 fieldManager.initializeFieldManager(idCanvas);
@@ -69,12 +72,52 @@ addCivilNoFieldButton.addEventListener('click', () => addNewField('civilNo', 'Ci
 addPhotoFieldButton.addEventListener('click', () => addNewField('photo', 'Photo'));
 
 fieldManager.fieldLayer.addEventListener('field:moved', (event) => {
-    const { id, x, y, width, height } = event.detail;
+    const { id, x, y, width, height, fontFamily, fontSize } = event.detail;
     if (fields[id]) {
         fields[id].x = x;
         fields[id].y = y;
         fields[id].width = width;
         fields[id].height = height;
+        if (fontFamily) fields[id].fontFamily = fontFamily;
+        if (fontSize) fields[id].fontSize = fontSize;
+    }
+});
+
+fieldManager.fieldLayer.addEventListener('field:focused', (event) => {
+    if (event.detail) {
+        selectedFieldId = event.detail.id;
+        const field = fields[selectedFieldId];
+        if (field && field.type !== 'photo') {
+            fontFamilySelect.value = field.fontFamily || 'Arial';
+            fontSizeInput.value = field.fontSize || 16;
+            fontFamilySelect.disabled = false;
+            fontSizeInput.disabled = false;
+        } else {
+            fontFamilySelect.disabled = true;
+            fontSizeInput.disabled = true;
+        }
+    } else {
+        selectedFieldId = null;
+        fontFamilySelect.disabled = true;
+        fontSizeInput.disabled = true;
+    }
+});
+
+fontFamilySelect.addEventListener('change', () => {
+    if (selectedFieldId && fields[selectedFieldId]) {
+        const val = fontFamilySelect.value;
+        fields[selectedFieldId].fontFamily = val;
+        const el = document.getElementById(selectedFieldId);
+        if (el) el.style.fontFamily = val;
+    }
+});
+
+fontSizeInput.addEventListener('change', () => {
+    if (selectedFieldId && fields[selectedFieldId]) {
+        const size = parseInt(fontSizeInput.value, 10) || 16;
+        fields[selectedFieldId].fontSize = size;
+        const el = document.getElementById(selectedFieldId);
+        if (el) el.style.fontSize = `${size}px`;
     }
 });
 
@@ -161,7 +204,6 @@ function renderSingleIdToContext(targetCtx, baseTemplate, fieldLayouts, textData
         targetCtx.drawImage(baseTemplate, 0, 0, targetCtx.canvas.width, targetCtx.canvas.height);
     }
 
-    targetCtx.font = '16px Arial'; // Example font, consider making this configurable per field
     targetCtx.fillStyle = 'black';
     targetCtx.textAlign = 'left';
     targetCtx.textBaseline = 'top';
@@ -212,6 +254,8 @@ function renderSingleIdToContext(targetCtx, baseTemplate, fieldLayouts, textData
         } else {
             let textToDraw = textDataById[field.id] || `[${field.type}]`;
             console.log(`For field ID ${field.id} (type ${field.type}), drawing text: "${textToDraw}"`);
+            targetCtx.font = `${field.fontSize || 16}px ${field.fontFamily || 'Arial'}`;
+            const lineHeight = field.fontSize || 16;
             // Basic text wrapping
             const lines = [];
             let currentLine = '';
@@ -229,7 +273,7 @@ function renderSingleIdToContext(targetCtx, baseTemplate, fieldLayouts, textData
             lines.push(currentLine);
 
             lines.forEach((line, index) => {
-                 targetCtx.fillText(line.trim(), x + 2, y + 2 + (index * 16)); // 16 for line height
+                 targetCtx.fillText(line.trim(), x + 2, y + 2 + (index * lineHeight));
             });
         }
     }
@@ -398,6 +442,8 @@ window.addEventListener('DOMContentLoaded', () => {
     }
     downloadPreviewButton.disabled = true;
     downloadAllButton.style.display = 'none';
+    fontFamilySelect.disabled = true;
+    fontSizeInput.disabled = true;
 });
 
 // For easier debugging

--- a/js/fieldManager.js
+++ b/js/fieldManager.js
@@ -46,6 +46,15 @@ function setFocusedField(fieldElement) {
         fieldElement.classList.add('focused');
     }
     focusedField = fieldElement;
+    const event = new CustomEvent('field:focused', {
+        detail: fieldElement
+            ? {
+                  id: fieldElement.id,
+                  type: fieldElement.dataset.type
+              }
+            : null
+    });
+    fieldLayer.dispatchEvent(event);
 }
 
 export function updateFieldLayerPosition() {
@@ -91,6 +100,9 @@ export function addField(type, placeholderText = 'Text Field') {
     field.style.height = '120px';
     field.textContent = 'Photo Area';
   } else { // Text field: auto-size
+    // Default font styles for text fields
+    field.style.fontFamily = 'Arial';
+    field.style.fontSize = '16px';
     field.style.width = 'auto';
     field.style.height = 'auto';
     // Force reflow if needed, then get dimensions
@@ -198,7 +210,17 @@ export function addField(type, placeholderText = 'Text Field') {
   }
   
   dispatchFieldUpdate(field); // Dispatch initial state
-  return { id, type, x: field.offsetLeft, y: field.offsetTop, width: field.offsetWidth, height: field.offsetHeight, text: field.textContent };
+  return {
+    id,
+    type,
+    x: field.offsetLeft,
+    y: field.offsetTop,
+    width: field.offsetWidth,
+    height: field.offsetHeight,
+    text: field.textContent,
+    fontFamily: field.style.fontFamily || 'Arial',
+    fontSize: parseInt(field.style.fontSize, 10) || 16
+  };
 }
 
 function dispatchFieldUpdate(fieldElement) {
@@ -210,7 +232,9 @@ function dispatchFieldUpdate(fieldElement) {
       y: fieldElement.offsetTop,
       width: fieldElement.offsetWidth,
       height: fieldElement.offsetHeight,
-      text: fieldElement.textContent
+      text: fieldElement.textContent,
+      fontFamily: fieldElement.style.fontFamily || 'Arial',
+      fontSize: parseInt(fieldElement.style.fontSize, 10) || 16
     }
   });
   fieldLayer.dispatchEvent(event);
@@ -228,7 +252,9 @@ export function getFieldPositions() {
       y: field.offsetTop,
       width: field.offsetWidth,
       height: field.offsetHeight,
-      text: field.textContent
+      text: field.textContent,
+      fontFamily: field.style.fontFamily || 'Arial',
+      fontSize: parseInt(field.style.fontSize, 10) || 16
     };
   }
   return positions;


### PR DESCRIPTION
## Summary
- store font family and size for text fields
- allow editing font settings in the UI
- apply chosen font when rendering IDs
- dispatch new `field:focused` events

## Testing
- `npm test` *(fails: Missing script)*