### PR TITLE
Hide field overlays after generating ID

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -60,6 +60,7 @@ templateUpload.addEventListener('change', (event) => {
 });
 
 function addNewField(type, placeholderText) {
+    fieldManager.showAllFields();
     if (!templateImage) {
         alert('Please upload an ID template image first.');
         return;
@@ -377,6 +378,7 @@ generateButton.addEventListener('click', async () => {
                     previewImage.onload = () => {
                         ctx.clearRect(0, 0, idCanvas.width, idCanvas.height);
                         ctx.drawImage(previewImage, 0, 0);
+                        fieldManager.hideAllFields();
                     };
                     previewImage.src = dataUrl;
                 }

--- a/js/fieldManager.js
+++ b/js/fieldManager.js
@@ -272,6 +272,24 @@ export function clearFields() {
     setFocusedField(null);
 }
 
+export function hideAllFields() {
+    for (const id in fields) {
+        const field = fields[id];
+        if (field) {
+            field.style.display = 'none';
+        }
+    }
+}
+
+export function showAllFields() {
+    for (const id in fields) {
+        const field = fields[id];
+        if (field) {
+            field.style.display = '';
+        }
+    }
+}
+
 export function cleanupFieldManager() {
     window.removeEventListener('resize', updateFieldLayerPosition);
     document.removeEventListener('click', handleDocumentClick, true);


### PR DESCRIPTION
## Summary
- add hideAllFields and showAllFields utilities to `fieldManager`
- ensure new fields re-show overlays
- hide overlays after previewing the first generated ID

## Testing
- `npm test` *(fails: Missing script)*