### PR TITLE
Fix overlay persistence in edit layout mode

### DIFF
--- a/js/fieldManager.js
+++ b/js/fieldManager.js
@@ -273,20 +273,34 @@ export function clearFields() {
 }
 
 export function hideAllFields() {
+    // Hide fields tracked in the fields map
     for (const id in fields) {
         const field = fields[id];
         if (field) {
             field.style.display = 'none';
         }
     }
+    // Also hide any orphaned overlays that might not be tracked
+    if (fieldLayer && fieldLayer.children) {
+        Array.from(fieldLayer.children).forEach(child => {
+            child.style.display = 'none';
+        });
+    }
 }
 
 export function showAllFields() {
+    // Show fields tracked in the fields map
     for (const id in fields) {
         const field = fields[id];
         if (field) {
             field.style.display = '';
         }
+    }
+    // Also show any orphaned overlays just in case
+    if (fieldLayer && fieldLayer.children) {
+        Array.from(fieldLayer.children).forEach(child => {
+            child.style.display = '';
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- hide any untracked overlay elements during generation
- ensure orphaned overlays reappear when entering edit mode

## Testing
- `git status --short`