### PR TITLE
Fix overlay hiding after edit mode

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -291,6 +291,7 @@ generateButton.addEventListener('click', async () => {
     }
 
     const numIDs = parseInt(numIDsToGenerateInput.value) || 1;
+    fieldManager.hideAllFields(); // Ensure any visible overlays are hidden before generating
     generateButton.disabled = true;
     generateButton.textContent = 'Generating...';
     generatedIdObjects = []; // Clear previous results


### PR DESCRIPTION
## Summary
- hide all overlays immediately when generating IDs to avoid leftover HTML fields

## Testing
- `npm test` *(fails: Missing script)*
- `bun test`